### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# GOB
+# Gemeentelijke Ontsluiting Basisregistraties (GOB)
 
-Generic Disclosure of Key Registrations
+Generic Access of Key Registrations 
 
 _Een Nederlandse (beperkt onderhouden) versie van dit document is beschikbaar in [README.nl](README.nl.md)_
 


### PR DESCRIPTION
Disclosure seems to be the wrong translation for 'ontsluiting': 
https://www.google.com/search?client=firefox-b-ab&ei=N488XJehBZDVwQLrtKfQAg&q=disclosure+vertaling&oq=disclosure+vertaling&gs_l=psy-ab.3..0l2j0i22i30l8.1899.5030..5176...0.0..0.158.953.5j5......0....1..gws-wiz.......0i71j0i67j0i10.xz-2I5I-PHI
It is used when you say 'openbaring'

Gegevens ontsluiting translates better:
https://www.google.com/search?client=firefox-b-ab&ei=Wo88XI36BJCz0gXi4JToBA&q=gegevens+ontsluiting+engels&oq=gegevens+ontsluiting+engels&gs_l=psy-ab.3...2873.3711..4015...0.0..1.193.1005.3j6......0....1..gws-wiz.GfrIMSMyeGM
Access seems to be used more in this context. Also added the literal Dutch translation to know how GOB is abbreviated.